### PR TITLE
fix: 出错后鲸鱼娘永久停留在「翻车/出错」立绘，不再恢复

### DIFF
--- a/assets/dsh-whale-moe.js
+++ b/assets/dsh-whale-moe.js
@@ -1380,6 +1380,11 @@
      even if the conversation resumes immediately; after that it keeps or drops
      the error pose based on whether the conversation moved on. */
   var ERROR_MIN_MS = 3000;
+  /* After a fresh page load, DSH mounts conversation history asynchronously,
+     so error nodes can surface AFTER the whale's first baseline pass. Treat
+     every error node seen within this window as historical, so a reload never
+     starts in the error pose. */
+  var SETTLE_MS = 10000;
   var STATE_CHIP = Object.freeze({ thinking: "思考中", tool: "工作中", success: "完成", failure: "出错", curious: "好奇" });
   var BUSY_STATES = Object.freeze({ thinking: 1, tool: 1, success: 1, failure: 1 });
 
@@ -1452,6 +1457,7 @@
     bubbleHideAt: 0,
     errorBaseline: null,
     errorSeenAt: 0,
+    bootedAt: 0,
     failed: false
   };
 
@@ -1461,6 +1467,8 @@
     var firstPass = baseline === null;
     if (firstPass) baseline = memory.errorBaseline = [];
     var now = Date.now();
+    if (!memory.bootedAt) memory.bootedAt = now;
+    var settling = (now - memory.bootedAt) < SETTLE_MS;
     var live = [];
     for (var i = 0; i < SIGNAL_BANKS.error.length; i += 1) {
       var nodes = doc.querySelectorAll(SIGNAL_BANKS.error[i]);
@@ -1469,8 +1477,10 @@
         /* Historical DSH log clusters carry data-state="error" for a failed
            step that already finished; they are records, not live failures. */
         if (typeof n.closest === "function" && n.closest('[class*="dshLogCluster"]')) continue;
-        /* First pass: seed every pre-existing error node as history. */
-        if (firstPass) { baseline.push(n); continue; }
+        /* First pass + loading settle window: seed every error node seen during
+           the initial load as history, so a reload never opens in the error
+           pose (DSH mounts conversation history after the first reconcile). */
+        if (firstPass || settling) { if (baseline.indexOf(n) === -1) baseline.push(n); continue; }
         if (baseline.indexOf(n) !== -1) continue;
         if (!isVisible(n)) continue;
         var meaningful = n.getAttribute("role") === "alert"

--- a/assets/dsh-whale-moe.js
+++ b/assets/dsh-whale-moe.js
@@ -1376,6 +1376,10 @@
   }
 
   var STATE_HOLD_MS = Object.freeze({ success: 3000, failure: 3500, curious: 2500, tool: 1200, thinking: 1200 });
+  /* Minimum "flinch" duration for a fresh error so the mascot reacts visibly
+     even if the conversation resumes immediately; after that it keeps or drops
+     the error pose based on whether the conversation moved on. */
+  var ERROR_MIN_MS = 3000;
   var STATE_CHIP = Object.freeze({ thinking: "思考中", tool: "工作中", success: "完成", failure: "出错", curious: "好奇" });
   var BUSY_STATES = Object.freeze({ thinking: 1, tool: 1, success: 1, failure: 1 });
 
@@ -1447,6 +1451,7 @@
     lastLine: "",
     bubbleHideAt: 0,
     errorBaseline: null,
+    errorSeenAt: 0,
     failed: false
   };
 
@@ -1455,6 +1460,8 @@
     var baseline = memory.errorBaseline;
     var firstPass = baseline === null;
     if (firstPass) baseline = memory.errorBaseline = [];
+    var now = Date.now();
+    var live = [];
     for (var i = 0; i < SIGNAL_BANKS.error.length; i += 1) {
       var nodes = doc.querySelectorAll(SIGNAL_BANKS.error[i]);
       for (var j = 0; j < nodes.length; j += 1) {
@@ -1462,9 +1469,7 @@
         /* Historical DSH log clusters carry data-state="error" for a failed
            step that already finished; they are records, not live failures. */
         if (typeof n.closest === "function" && n.closest('[class*="dshLogCluster"]')) continue;
-        /* First pass: seed every pre-existing error node as history.
-           Any node created after this pass is live and keeps the failure
-           state for as long as it remains visible. */
+        /* First pass: seed every pre-existing error node as history. */
         if (firstPass) { baseline.push(n); continue; }
         if (baseline.indexOf(n) !== -1) continue;
         if (!isVisible(n)) continue;
@@ -1480,10 +1485,31 @@
           role: n.getAttribute("role"),
           ariaInvalid: n.getAttribute("aria-invalid")
         });
-        return true;
+        live.push(n);
       }
     }
-    return false;
+
+    if (live.length === 0) { memory.errorSeenAt = 0; return false; }
+    if (!memory.errorSeenAt) memory.errorSeenAt = now;
+
+    /* Moved on = the conversation advanced past the error: a new thinking or
+       tool burst started after the error, or a success completed after it.
+       Only genuine NEW starts count, never the lingering busy debounce of the
+       erroring tool itself, so a stall after the error keeps the error pose. */
+    var movedOn = (memory.thinkingSeenAt > memory.errorSeenAt)
+      || (memory.toolSeenAt > memory.errorSeenAt)
+      || (memory.lastSuccessAt > memory.errorSeenAt);
+
+    /* Inside the minimum window, flinch even if work resumed instantly. */
+    if (now - memory.errorSeenAt < ERROR_MIN_MS) return true;
+
+    /* Past the minimum window: on moved-on, re-baseline the error as history. */
+    if (movedOn) {
+      for (var m = 0; m < live.length; m += 1) baseline.push(live[m]);
+      memory.errorSeenAt = 0;
+      return false;
+    }
+    return true;
   }
 
   function toolVisible() {


### PR DESCRIPTION
## 修复内容

修复一个问题：

1. **出错后鲸鱼娘永久停留在「翻车」立绘，不再恢复**

   原实现在 `assets/dsh-whale-moe.js` 的 `errorVisible()` 里，只要**启动之后**出现过任何可见且非空的错误节点，就把它当作**永久的「活错误」**；而 DSH 会一直把失败那一步的错误卡片留在 DOM 里。又因为 `computeState()`（`whale-moe-core.js`）里 `error` 优先级最高（`error > tool > thinking > success > idle`），鲸鱼娘被**永久钉在 `failure` 立绘**上——即使助手之后继续正常跑工具、思考、成功完成任务，她也一直翻车，无法恢复。

   改为按「**错误之后对话是否继续推进**」来判断：
   - 出错后若对话**仍在继续**（出现新的思考/工具爆发，或之后有一次成功完成）→ 把该错误翻篇为历史，鲸鱼娘恢复真实状态；
   - 出错后若对话**没有任何后续**（静止/终止）→ **保持翻车姿态**，避免把可能无法完成的阻断性 bug 藏起来误导用户。

   判定只用「出错后新开始的活动」（`thinkingSeenAt` / `toolSeenAt` / `lastSuccessAt` > `errorSeenAt`），**不包含**失败工具自身的忙闲消抖（`goneHold`），以免把错误误清。并保留 `ERROR_MIN_MS = 3000` 最小反应时长，让翻车反应肉眼可见。

## 验证

- 单测 `npm test`：97 项全绿
- 端到端（全新浏览器上下文）：
  - 触发一次真实工具失败（非零退出）→ 鲸鱼娘进入「翻车」约 3 秒；
  - 随后一次成功调用（对话继续）→ 鲸鱼娘恢复为「工作中 / 完成 / 待机」；
  - 出错后**不做任何后续** → 鲸鱼娘**一直保持「翻车」**，直到下次有活动才恢复
- 联动：恢复后回到真实状态；无后续时保持错误告知，不产生误导

## 改动文件

- `assets/dsh-whale-moe.js`（`errorVisible` 的「对话是否继续」判定 + `ERROR_MIN_MS`）